### PR TITLE
Randomness

### DIFF
--- a/voting/views.py
+++ b/voting/views.py
@@ -2,6 +2,7 @@ from braces.views import LoginRequiredMixin
 from django.contrib.auth import authenticate, login
 from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import DetailView, ListView, TemplateView, View
+from random import shuffle
 
 from .models import Proposal, Vote
 
@@ -13,7 +14,9 @@ class Home(LoginRequiredMixin, TemplateView):
         proposals = Proposal.objects.exclude(vote__user=self.request.user)
         if not proposals:
             return super().get(request, *args, **kwargs)
-        return redirect('proposal-detail', pk=proposals.order_by('?').first().pk)
+        results = list(proposals.objects)
+        results.shuffle()
+        return redirect('proposal-detail', pk=results[0].pk)
 
 
 class Login(TemplateView):


### PR DESCRIPTION
According to [this StackOverflow question](http://stackoverflow.com/questions/25961092/django-random-orderingorder-by-makes-additional-query) using `random.shuffle()` will reduce the number of DB queries by 1. Possibly. Also, if we add a caching layer in future, the random order produced by `order_by` will be cached, so using `shuffle` future-proofs the random ordering of talk proposals.

Please don't merge this without testing it, I have zero experience with Django, so bugs are highly likely...
